### PR TITLE
Only modify buffer if necessary

### DIFF
--- a/autoload/gofmt.vim
+++ b/autoload/gofmt.vim
@@ -66,6 +66,14 @@ function! gofmt#apply() abort
   endif
 
   let input = getline(1, '$') + ['']
+
+  let list_cmd = cmd . ' -l'
+  let list_output = system(list_cmd, input)
+  if empty(list_output)
+    echo "gofmt: no changes"
+    return
+  endif
+
   let output = system(cmd, input)
   let diff = split(output, "\n", 1)
   if v:shell_error != 0

--- a/autoload/gofmt.vim
+++ b/autoload/gofmt.vim
@@ -80,7 +80,7 @@ function! gofmt#apply() abort
     if get(g:, 'gofmt_display_errors', 0)
       echohl ErrorMsg
       echo output
-      echohl None      
+      echohl None
       return ''
     endif
   endif


### PR DESCRIPTION
Check the output of `g:gofmt_exe -l` and only modify the buffer if it is not empty.

See issue #5 